### PR TITLE
Add RT favicon to replace default browser tab icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Rudraksh Taya</title>
+    <link rel="icon" type="image/svg+xml" href="/rt-favicon.svg" />
   </head>
 
   <body>

--- a/public/rt-favicon.svg
+++ b/public/rt-favicon.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#6C5CE7"/>
+      <stop offset="100%" stop-color="#00C2FF"/>
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="12" fill="url(#g)"/>
+  <text x="50%" y="50%" text-anchor="middle" dominant-baseline="central"
+        font-family="Inter, system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif"
+        font-weight="800" font-size="28" fill="#FFFFFF">RT</text>
+</svg>


### PR DESCRIPTION
## Purpose
Fix the runtime error and improve branding by adding a custom favicon with "RT" initials to replace the default browser tab icon for the Rudraksh Taya website.

## Code changes
- Added favicon link reference in `index.html` pointing to `/rt-favicon.svg`
- Created new `rt-favicon.svg` file with:
  - Purple to blue gradient background with rounded corners
  - White "RT" text using Inter font family
  - 64x64 viewBox optimized for browser tab display

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 9`

🔗 [Edit in Builder.io](https://builder.io/app/projects/514eed1a3a524dc1bd5cbf4380b225a7/vortex-verse)

👀 [Preview Link](https://514eed1a3a524dc1bd5cbf4380b225a7-vortex-verse.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>514eed1a3a524dc1bd5cbf4380b225a7</projectId>-->
<!--<branchName>vortex-verse</branchName>-->